### PR TITLE
Jiwon

### DIFF
--- a/jiwon/소수만들기.js
+++ b/jiwon/소수만들기.js
@@ -1,0 +1,25 @@
+function is_prime(num) { 
+  if (num === 1) return false;
+  for (let i = 2; i * i <= num; i++) {
+    if (num % i === 0) return false;
+  }
+  return true;
+}
+function solution(nums) {
+  var answer = 0;
+  const arr_sum = [];
+
+  for(let i = 0; i < nums.length - 2; i++) {
+    for (let j = i + 1; j < nums.length - 1; j++) {
+      for (let k = j + 1; k < nums.length; k++) {
+        arr_sum.push(nums[i] + nums[j] + nums[k]);
+      }
+    }
+  }
+  arr_sum.forEach(elem => {
+    if (is_prime(elem)) {
+      answer++;
+    }
+  })
+  return answer;
+}

--- a/jiwon/숫자문자열과영단어.js
+++ b/jiwon/숫자문자열과영단어.js
@@ -1,0 +1,23 @@
+function solution(s) {
+  var answer = 0;
+  const dict = ["zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine"];
+  const s_arr = s.split("", s.length);
+  console.log(s_arr);
+  s_arr.map((elem)=> {
+    if (elem >= "0", elem <= "9") {
+      answer = answer*10 + parseInt(elem);
+      s = s.substr(1);
+    }
+    else {
+      var i = 0;
+      dict.map(num => {
+        if (s.indexOf(num) === 0) {
+          answer = answer*10 + i;
+          s = s.substr(num.length)
+        }
+        i ++;
+      })
+    }
+  })
+  return answer;
+}


### PR DESCRIPTION
## 💻 풀이 문제

-   [숫자 문자열과 영단어](https://programmers.co.kr/learn/courses/30/lessons/81301)
-  [소수만들기](https://programmers.co.kr/learn/courses/30/lessons/12977)


## 🚩 문제에 필요한 개념
### 숫자 문자열과 영단어
-   string -> array 변환하기: `string.split("", string.length)`
-  문자열 내에서 특정 키워드의 시작 인덱스 찾기: `string.indexOf(keyword)`
-  문자열 내에서 특정 키워드만 남기기: `string.substr(시작index, 끝index)`
### 소수만들기
- 소수 판별 함수 내부에서 i*i <= n 까지만 반복하는 이유는 n=7이고 i=2일 때 n%i (7/2 = 3...1) 을 구했다면 i=3 일 때 n%i (7/3 = 2...1) 을 구해줄 필요가 없기 때문이다.

## 🦜 문제 풀이
### 숫자 문자열과 영단어
- 숫자와 영단어가 섞인 문자열 s를 배열로 변환시켜준 뒤 맨 앞 index가 숫자면 해당 숫자를 answer의 마지막 자릿수로 넣어주고 문자열 s에서 맨 앞 index 값을 삭제한다.
- 맨 앞 index가 숫자가 아닐 땐 영단어가 시작 된 것이므로 
"zero"부터 "nine"까지의 문자열이 들어간 배열 dict로 map함수를 돌려주어 
s.indexOf(element)의 값이 0이 될 때 dict 내 element의 인덱스를 answer의 마지막 자릿수로 넣어주고 element의 길이만큼 s에서 삭제해준다.

### 소수만들기
- nums 원소의 최대 갯수가 50개이기 때문에 3중 for문을 이용해 3개의 원소를 더해준 모든 값을 구해준 후 각 값을 소수 판별 함수에 넣어줬다.
- 소수 판별 함수는 2부터 시작하는 변수 i에  1씩 더하며 i^2이 n보다 커지기 전까지 파라미터로 넘어온 num과 나누어 떨어지지 않는다면, num은 2 이상의 약수가 없다는 원리를 이용해 구현했다.
